### PR TITLE
- remove the unnecessary python tag from loggly events

### DIFF
--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -156,7 +156,6 @@ def make_loggly_handler(graph, formatter):
         base_url,
         graph.config.logging.loggly.token,
         ",".join([
-            "python",
             graph.metadata.name,
             graph.config.logging.loggly.environment,
         ]),


### PR DESCRIPTION
Grouping log events by tag is really useful for charts. Tracking events by language isn't very helpful.