### PR TITLE
Only enable loggly if configured.

### DIFF
--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -64,10 +64,13 @@ def enable_loggly(graph):
     if not graph.config.logging.loggly.enabled:
         return False
 
-    if not graph.config.logging.loggly.token:
-        return False
+    try:
+        if not graph.config.logging.loggly.token:
+            return False
 
-    if not graph.config.logging.loggly.environment:
+        if not graph.config.logging.loggly.environment:
+            return False
+    except AttributeError:
         return False
 
     return True

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -28,7 +28,7 @@ from microcosm.api import defaults
         ),
     ),
 
-    # loggly is enabled (unless debug/testing are set)
+    # loggly is enabled (unless debug/testing or not configured)
     loggly=dict(
         enabled=True,
     ),
@@ -57,6 +57,22 @@ def configure_logger(graph):
     return getLogger(graph.metadata.name)
 
 
+def enable_loggly(graph):
+    if graph.metadata.debug or graph.metadata.testing:
+        return False
+
+    if not graph.config.logging.loggly.enabled:
+        return False
+
+    if not graph.config.logging.loggly.token:
+        return False
+
+    if not graph.config.logging.loggly.environment:
+        return False
+
+    return True
+
+
 def make_dict_config(graph):
     """
     Build a dictionary configuration from conventions and configuration.
@@ -71,7 +87,7 @@ def make_dict_config(graph):
     handlers["console"] = make_stream_handler(graph, formatter="default")
 
     # maybe create the loggly handler
-    if not any((graph.metadata.debug, graph.metadata.testing)) and graph.config.logging.loggly.enabled:
+    if enable_loggly(graph):
         formatters["JSONFormatter"] = make_json_formatter(graph)
         handlers["LogglyHTTPSHandler"] = make_loggly_handler(graph, formatter="JSONFormatter")
 

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -9,6 +9,8 @@ from microcosm.api import defaults
 
 
 @defaults(
+    default_format="%(asctime)s - %(name)-12s - [%(levelname)s] - %(message)s",
+
     # default log level is INFO
     level="INFO",
 
@@ -120,7 +122,7 @@ def make_default_formatter(graph):
 
     """
     return {
-        "format": "%(asctime)s - %(name)-12s - [%(levelname)s] - %(message)s"
+        "format": graph.config.logging.default_format,
     }
 
 

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -29,11 +29,6 @@ from microcosm.api import defaults
             error=[],
         ),
     ),
-
-    # loggly is enabled (unless debug/testing or not configured)
-    loggly=dict(
-        enabled=True,
-    ),
 )
 def configure_logging(graph):
     """
@@ -60,10 +55,11 @@ def configure_logger(graph):
 
 
 def enable_loggly(graph):
-    if graph.metadata.debug or graph.metadata.testing:
-        return False
+    """
+    Enable loggly if it is configured and not debug/testing.
 
-    if not graph.config.logging.loggly.enabled:
+    """
+    if graph.metadata.debug or graph.metadata.testing:
         return False
 
     try:

--- a/microcosm_logging/tests/test_factories.py
+++ b/microcosm_logging/tests/test_factories.py
@@ -78,42 +78,6 @@ def test_configure_logging_with_custom_library_levels():
     getLogger("foo").warn("Foo should be visible at warn")
 
 
-def test_configure_logging_with_loggly_requires_token():
-    """
-    Enabling loggly requires `token` attribute.
-
-    """
-    def loader(metadata):
-        return dict(
-            logging=dict(
-                loggly=dict(
-                    environment="unittest",
-                )
-            )
-        )
-
-    graph = create_object_graph(name="test", loader=loader)
-    assert_that(calling(graph.use).with_args("logger"), raises(AttributeError))
-
-
-def test_configure_logging_with_loggly_requires_environment():
-    """
-    Enabling loggly requires `token` and `environment` attributes.
-
-    """
-    def loader(metadata):
-        return dict(
-            logging=dict(
-                loggly=dict(
-                    token="TOKEN",
-                )
-            )
-        )
-
-    graph = create_object_graph(name="test", loader=loader)
-    assert_that(calling(graph.use).with_args("logger"), raises(AttributeError))
-
-
 def test_configure_logging_with_invalid_token():
     """
     Enabling loggly.

--- a/microcosm_logging/tests/test_factories.py
+++ b/microcosm_logging/tests/test_factories.py
@@ -1,15 +1,11 @@
 from logging import getLogger, DEBUG, INFO, WARN
 from os import environ
 
-
 from hamcrest import (
     assert_that,
-    calling,
     equal_to,
     is_,
-    raises,
 )
-
 from microcosm.api import create_object_graph
 
 


### PR DESCRIPTION
Initially, we were enabling loggly in all non-dev and non-test executions. That was useful
when our configuration system wasn't very robust but is just annoying now when using microcosm
in non-loggly contexts.