### PR TITLE
fix logger adapter to use logger extra properly

### DIFF
--- a/microcosm_logging/decorators.py
+++ b/microcosm_logging/decorators.py
@@ -30,11 +30,8 @@ class ContextLogger(LoggerAdapter):
 
     """
     def process(self, msg, kwargs):
-        extra = kwargs.get('extra')
-        if extra is not None:
-            kwargs['extra'].update(self.extra)
-        else:
-            kwargs['extra'] = self.extra
+        kwargs.setdefault('extra', {})
+        kwargs['extra'].update(self.extra)
         return msg, kwargs
 
 

--- a/microcosm_logging/decorators.py
+++ b/microcosm_logging/decorators.py
@@ -30,8 +30,11 @@ class ContextLogger(LoggerAdapter):
 
     """
     def process(self, msg, kwargs):
-        if isinstance(msg, dict):
-            msg.update(self.extra)
+        extra = kwargs.get('extra')
+        if extra is not None:
+            kwargs['extra'].update(self.extra)
+        else:
+            kwargs['extra'] = self.extra
         return msg, kwargs
 
 


### PR DESCRIPTION
It looks like the JsonFormatter uses the logger extra property properly out of the box so I just needed to fix how the ContextLogger treats params in its process function.

The following code:

```
 47         self.logger.info(dict(message="so what do i get logged as dict?"))                        
 48         self.logger.info("so what do i get 2? logged as id", extra=dict(foo='bar'))
```

Will produce these two logs in loggly:

<img width="404" alt="screen shot 2016-08-22 at 11 40 02 am" src="https://cloud.githubusercontent.com/assets/5201654/17866912/3468bc94-685d-11e6-9727-dfe0980cdfff.png">

<img width="378" alt="screen shot 2016-08-22 at 11 40 40 am" src="https://cloud.githubusercontent.com/assets/5201654/17866934/4f00ed7e-685d-11e6-9cdb-1153235d8272.png">

Note how extra gets merged into the json body that shows up in loggly.

@sethisernhagen  @jessemyers @srt32 