### PR TITLE
Fixing usage of logger extra kwarg.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.2
+current_version = 0.9.3
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-logging"
-version = "0.9.2"
+version = "0.9.3"
 
 setup(
     name=project,


### PR DESCRIPTION
I'm doing this as a hotfix because I don't consider the way the ContextLogger treated the logger extra kwarg correctly.