### PR TITLE
Expose log level and logger name in json logs.

### DIFF
--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -10,6 +10,7 @@ from microcosm.api import defaults
 
 @defaults(
     default_format="{asctime} - {name} - [{levelname}] - {message}",
+    json_required_keys="%(asctime)s - %(name)s - %(filename)s - %(levelname)s - %(levelno) - %(message)s",
 
     https_handler=dict(
         class_="loggly.handlers.HTTPSHandler",
@@ -137,6 +138,7 @@ def make_json_formatter(graph):
 
     return {
         "()": graph.config.logging.json_formatter.formatter,
+        "fmt": graph.config.logging.json_required_keys,
     }
 
 


### PR DESCRIPTION
Right now json logs from microcosm logging are hard to use because they
are missing level name or logger name. Both make searching log results
easier. The former allows you to filter for errors or exceptions. The
latter allows you to filter to logs from a specific logger, which is
extremely convenient for filtering logs to a specific microcosm-pubsub
daemon handler.