### PR TITLE
Support logging levels that are dynamically generated.

### DIFF
--- a/microcosm_logging/levels.py
+++ b/microcosm_logging/levels.py
@@ -1,0 +1,53 @@
+"""
+Logging levels
+
+"""
+from functools import total_ordering
+
+
+@total_ordering
+class ConditionalLoggingLevel(object):
+    """
+    A logging level that is conditional on a function.
+
+    Works by masquerading as an int.
+
+    """
+    def __init__(self, true_levelno, false_levelno, func):
+        self._true_levelno = true_levelno
+        self._false_levelno = false_levelno
+        self._func = func
+
+    @property
+    def levelno(self):
+        if self._func():
+            return self._true_levelno
+        else:
+            return self._false_levelno
+
+    def __str__(self):
+        return str(self.levelno)
+
+    def __repr__(self):
+        return self.levelno
+
+    def __eq__(self, other):
+        if hasattr(other, "levelno"):
+            return self.levelno == other.levelno
+        else:
+            return self.levelno == other
+
+    def __lt__(self, other):
+        if hasattr(other, "levelno"):
+            return self.levelno < other.levelno
+        else:
+            return self.levelno < other
+
+    @classmethod
+    def setLevel(cls, logger, *args, **kwargs):
+        """
+        Set a conditional log level.
+
+        """
+        # NB: set `logger.level` because loggers validate the type of the input to `logger.setLevel()`
+        logger.level = cls(*args, **kwargs)

--- a/microcosm_logging/tests/test_levels.py
+++ b/microcosm_logging/tests/test_levels.py
@@ -1,0 +1,25 @@
+"""
+Test logging levels.
+
+"""
+from logging import getLogger, INFO, WARNING
+from hamcrest import assert_that, equal_to, is_
+
+from microcosm_logging.levels import ConditionalLoggingLevel
+
+
+def test_conditional_level():
+    logger = getLogger("foo.bar")
+
+    value = True
+
+    def toggle():
+        return value
+
+    ConditionalLoggingLevel.setLevel(logger, INFO, WARNING, toggle)
+
+    assert_that(logger.getEffectiveLevel(), is_(equal_to(INFO)))
+
+    value = False
+
+    assert_that(logger.getEffectiveLevel(), is_(equal_to(WARNING)))


### PR DESCRIPTION
This implementation takes advantage of the fact that Python logging has code
that looks like:

    if record.levelno >= hdlr.level:
        hdlr.handle(record)

This means that we can override the behavior of component log level resolution
by overriding comparison operations, enabling such use cases as setting a component's
level to `DEBUG` temporarily.