### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.2
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
 
 test:
   override:

--- a/microcosm_logging/decorators.py
+++ b/microcosm_logging/decorators.py
@@ -8,7 +8,7 @@ def logger(obj):
     Can be used on a Python class, e.g:
 
         @logger
-        class MyClass(object):
+        class MyClass:
             ...
 
 

--- a/microcosm_logging/levels.py
+++ b/microcosm_logging/levels.py
@@ -6,7 +6,7 @@ from functools import total_ordering
 
 
 @total_ordering
-class ConditionalLoggingLevel(object):
+class ConditionalLoggingLevel:
     """
     A logging level that is conditional on a function.
 

--- a/microcosm_logging/tests/test_decorators.py
+++ b/microcosm_logging/tests/test_decorators.py
@@ -14,13 +14,13 @@ from microcosm_logging.decorators import logger, context_logger
 
 
 @logger
-class TestClass(object):
+class TestClass:
 
     pass
 
 
 @logger
-class TestContextClass(object):
+class TestContextClass:
 
     def function(self):
         self.logger.info("success!")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-logging"
-version = "0.14.2"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -17,9 +17,9 @@ setup(
     keywords="microcosm",
     install_requires=[
         "loggly-python-handler>=1.0.0",
-        "microcosm>=0.17.0",
-        "python-json-logger>=0.1.5",
-        "requests[security]>=2.9.1",
+        "microcosm>=2.0.0",
+        "python-json-logger>=0.1.8",
+        "requests[security]>=2.18.4",
     ],
     setup_requires=[
         "nose>=1.3.6",
@@ -34,7 +34,7 @@ setup(
     },
     tests_require=[
         "coverage>=3.7.1",
-        "mock>=1.0.1",
-        "PyHamcrest>=1.8.5",
+        "mock>=2.0.0",
+        "PyHamcrest>=1.9.0",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py36, lint
 
 [testenv]
 commands =
@@ -10,7 +10,7 @@ deps =
 
 [testenv:lint]
 commands=flake8 --max-line-length 120 microcosm_logging
-basepython=python2.7
+basepython=python3.6
 deps=
     flake8
     flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version