### PR TITLE
python-json-logger 0.1.9 breaks microcosm-logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "loggly-python-handler>=1.0.0",
         "microcosm>=2.0.0",
-        "python-json-logger>=0.1.8",
+        "python-json-logger==0.1.8",
         "requests[security]>=2.18.4",
     ],
     setup_requires=[


### PR DESCRIPTION
Commit https://github.com/madzak/python-json-logger/pull/60 changed one of the arguments of merge_record_extra non-optional, breaking this lib. Constrain version until root issue is fixed.