### PR TITLE
Handle old-style %-formatter throwing ValueError

### DIFF
--- a/microcosm_logging/formatters.py
+++ b/microcosm_logging/formatters.py
@@ -51,7 +51,7 @@ class ExtraConsoleFormatter(Formatter):
         # support old-style formatting
         try:
             result = s % kwargs
-        except (KeyError, SyntaxError, TypeError):
+        except (KeyError, SyntaxError, TypeError, ValueError):
             pass
         else:
             if result != s:

--- a/microcosm_logging/tests/test_formatters.py
+++ b/microcosm_logging/tests/test_formatters.py
@@ -122,3 +122,25 @@ def test_extra_formatter_ignores_key_errors():
 
     log_result = formatter.format(log_record)
     assert_that(log_result, is_(equal_to(str(log_message))))
+
+
+def test_extra_formatter_ignores_malformed_old_format():
+    format_string = "{message}"
+    formatter = ExtraConsoleFormatter(format_string)
+
+    log_message = '%2C'
+    # This would cause the old formatter to throw:
+    # 'ValueError: unsupported format character 'C' (0x43) at index 2'
+
+    log_record = LogRecord(
+        'name',
+        INFO,
+        'some_function',
+        42,
+        log_message,
+        None,
+        0
+    )
+
+    log_result = formatter.format(log_record)
+    assert_that(log_result, is_(equal_to(str(log_message))))


### PR DESCRIPTION
Repro steps:
```
>>> from microcosm.object_graph import create_object_graph
>>> from microcosm_logging.factories import configure_logger
>>> g = create_object_graph("foo")
>>> l = configure_logger(g)
>>> l.info("%2C", extra=dict())
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 992, in emit
    msg = self.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 838, in format
    return fmt.format(record)
  File "/home/vince/.virtualenvs/foo/lib/python3.6/site-packages/microcosm_logging/formatters.py", line 30, in format
    message = self.format_safely(message, **extra)
  File "/home/vince/.virtualenvs/foo/lib/python3.6/site-packages/microcosm_logging/formatters.py", line 53, in format_safely
    result = s % kwargs
ValueError: unsupported format character 'C' (0x43) at index 2
```