### PR TITLE
Add another logging protection for requests-futures' FuturesSession

### DIFF
--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -29,7 +29,7 @@ from microcosm.api import defaults
             debug=[],
             info=["boto", "newrelic"],
             warn=["bravado_core", "requests", "botocore.vendored.requests", "swagger_spec_validator"],
-            error=["bravado.requests_client"],
+            error=["bravado.requests_client", "FuturesSession"],
         ),
         override=dict(
             debug=[],


### PR DESCRIPTION
The latest release of requests-futures ([0.9.9](https://github.com/ross/requests-futures/commit/b14916d82bfc31ad7ed01a14f2578f5638ce0d25))
causes errors when used with the loggly client. Loggly calls the futures
handler in such a way that causes it to emit a deprecation warning,
which then needs to be logged, which is then handled, which emits
the deprecation, and on and on.