### PR TITLE
Catch index error on log formatting

### DIFF
--- a/microcosm_logging/formatters.py
+++ b/microcosm_logging/formatters.py
@@ -60,7 +60,7 @@ class ExtraConsoleFormatter(Formatter):
         # support new-style formatting
         try:
             return s.format(**kwargs)
-        except KeyError:
+        except (KeyError, IndexError):
             pass
 
         # some messages will use '{' and '}' without meaning to use format strings


### PR DESCRIPTION
There's a edge case with a very niche logging format that previously would cause an IndexError to raise.  We would rather catch this case and continue, which we do in this PR.