### PR TITLE
replace `time.time()` with `time.perf_counter()` for timing

### DIFF
--- a/microcosm_logging/timing.py
+++ b/microcosm_logging/timing.py
@@ -3,14 +3,14 @@ Simple timer support for logging elapsed time.
 
 """
 from contextlib import contextmanager
-from time import time
+from time import perf_counter
 
 
 @contextmanager
 def elapsed_time(target):
-    start_time = time()
+    start_time = perf_counter()
     try:
         yield start_time
     finally:
-        elapsed_ms = (time() - start_time) * 1000
+        elapsed_ms = (perf_counter() - start_time) * 1000
         target["elapsed_time"] = elapsed_ms


### PR DESCRIPTION
Replace `time.time` with `time.perf_counter` for calculating elapsed time. `time.time` could jump around due to daylight savings, changing clock time, etc., whereas `perf_counter` is designed for measuring time intervals.