### PR TITLE
Adding metric name to daemons

### DIFF
--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -2,6 +2,7 @@
 Factory that configures logging.
 
 """
+from os import environ
 from logging import getLogger
 from logging.config import dictConfig
 
@@ -187,12 +188,14 @@ def make_loggly_handler(graph, formatter):
 
     """
     base_url = graph.config.logging.loggly.base_url
+    metric_service_name = environ.get("METRICS_NAME", graph.metadata.name)
     loggly_url = "{}/inputs/{}/tag/{}".format(
         base_url,
         graph.config.logging.loggly.token,
         ",".join([
             graph.metadata.name,
             graph.config.logging.loggly.environment,
+            metric_service_name
         ]),
     )
     return {

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -189,15 +189,25 @@ def make_loggly_handler(graph, formatter):
     """
     base_url = graph.config.logging.loggly.base_url
     metric_service_name = environ.get("METRICS_NAME", graph.metadata.name)
-    loggly_url = "{}/inputs/{}/tag/{}".format(
-        base_url,
-        graph.config.logging.loggly.token,
-        ",".join([
-            graph.metadata.name,
-            graph.config.logging.loggly.environment,
-            metric_service_name
-        ]),
-    )
+    if metric_service_name != graph.metadata.name:
+        loggly_url = "{}/inputs/{}/tag/{}".format(
+            base_url,
+            graph.config.logging.loggly.token,
+            ",".join([
+                graph.metadata.name,
+                graph.config.logging.loggly.environment,
+                metric_service_name,
+            ]),
+        )
+    else:
+        loggly_url = "{}/inputs/{}/tag/{}".format(
+            base_url,
+            graph.config.logging.loggly.token,
+            ",".join([
+                graph.metadata.name,
+                graph.config.logging.loggly.environment,
+            ]),
+        )
     return {
         "class": graph.config.logging.https_handler.class_,
         "formatter": formatter,

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -189,25 +189,15 @@ def make_loggly_handler(graph, formatter):
     """
     base_url = graph.config.logging.loggly.base_url
     metric_service_name = environ.get("METRICS_NAME", graph.metadata.name)
-    if metric_service_name != graph.metadata.name:
-        loggly_url = "{}/inputs/{}/tag/{}".format(
-            base_url,
-            graph.config.logging.loggly.token,
-            ",".join([
-                graph.metadata.name,
-                graph.config.logging.loggly.environment,
-                metric_service_name,
-            ]),
-        )
-    else:
-        loggly_url = "{}/inputs/{}/tag/{}".format(
-            base_url,
-            graph.config.logging.loggly.token,
-            ",".join([
-                graph.metadata.name,
-                graph.config.logging.loggly.environment,
-            ]),
-        )
+    loggly_url = "{}/inputs/{}/tag/{}".format(
+        base_url,
+        graph.config.logging.loggly.token,
+        ",".join(set([
+            graph.metadata.name,
+            graph.config.logging.loggly.environment,
+            metric_service_name,
+        ])),
+    )
     return {
         "class": graph.config.logging.https_handler.class_,
         "formatter": formatter,


### PR DESCRIPTION
This change is to add metric name when logging from daemon to loggly.

Closes: GLOB-41581


Daemons are using metadata name currently as a tag. This change adds metric name to give daemons additional relevant identification tag in Loggly.

