### PR TITLE
Allow to bump logging level of a logger

### DIFF
--- a/microcosm_logging/tests/test_factories.py
+++ b/microcosm_logging/tests/test_factories.py
@@ -5,105 +5,149 @@ from logging import (
     getLogger,
 )
 from os import environ
+from unittest import TestCase
 
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    equal_to,
+    is_,
+)
 from microcosm.api import create_object_graph
 
 
-def test_configure_logging_with_defaults():
-    """
-    Default logging configuration works and enables INFO level logging.
+class TestFactories(TestCase):
 
-    """
-    graph = create_object_graph(name="test", testing=True)
+    def test_configure_logging_with_defaults(self):
+        """
+        Default logging configuration works and enables INFO level logging.
 
-    assert_that(graph.logger, is_(equal_to(getLogger("test"))))
-    assert_that(graph.logger.getEffectiveLevel(), is_(equal_to(INFO)))
+        """
+        graph = create_object_graph(name="test", testing=True)
 
-    graph.logger.info("Info is enabled by default")
-    graph.logger.debug("Debug is not enabled by default")
+        assert_that(graph.logger, is_(equal_to(getLogger("test"))))
+        assert_that(graph.logger.getEffectiveLevel(), is_(equal_to(INFO)))
 
+        graph.logger.info("Info is enabled by default")
+        graph.logger.debug("Debug is not enabled by default")
 
-def test_configure_logging_with_custom_logging_level():
-    """
-    The system-wide logging level can be overridden.
+    def test_configure_logging_with_custom_logging_level(self):
+        """
+        The system-wide logging level can be overridden.
 
-    """
-    def loader(metadata):
-        return dict(
-            logging=dict(
-                level="DEBUG",
+        """
+        def loader(metadata):
+            return dict(
+                logging=dict(
+                    level="DEBUG",
+                )
             )
-        )
 
-    graph = create_object_graph(name="test", testing=True, loader=loader)
+        graph = create_object_graph(name="test", testing=True, loader=loader)
 
-    assert_that(graph.logger.getEffectiveLevel(), is_(equal_to(DEBUG)))
+        assert_that(graph.logger.getEffectiveLevel(), is_(equal_to(DEBUG)))
 
-    graph.logger.info("Info is enabled by default")
-    graph.logger.debug("Debug is enabled by configuration")
+        graph.logger.info("Info is enabled by default")
+        graph.logger.debug("Debug is enabled by configuration")
 
+    def test_configure_logging_with_custom_library_levels(self):
+        """
+        Logging levels can be configured.
 
-def test_configure_logging_with_custom_library_levels():
-    """
-    Logging levels can be configured.
-
-    """
-    def loader(metadata):
-        return dict(
-            logging=dict(
-                level=INFO,
-                levels=dict(
-                    default=dict(
-                        debug=["foo", "bar"],
-                    ),
-                    override=dict(
-                        warn=["foo"],
+        """
+        def loader(metadata):
+            return dict(
+                logging=dict(
+                    level=INFO,
+                    levels=dict(
+                        default=dict(
+                            debug=["foo", "bar"],
+                        ),
+                        override=dict(
+                            warn=["foo"],
+                        )
                     )
                 )
             )
-        )
 
-    graph = create_object_graph(name="test", testing=True, loader=loader)
-    graph.use("logger")
+        graph = create_object_graph(name="test", testing=True, loader=loader)
+        graph.use("logger")
 
-    assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(WARN)))
-    assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(DEBUG)))
+        assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(WARN)))
+        assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(DEBUG)))
 
-    getLogger("bar").info("Bar should be visible at info")
-    getLogger("foo").info("Foo should not be visible at info")
-    getLogger("foo").warn("Foo should be visible at warn")
+        getLogger("bar").info("Bar should be visible at info")
+        getLogger("foo").info("Foo should not be visible at info")
+        getLogger("foo").warn("Foo should be visible at warn")
 
+    def test_configure_logging_with_invalid_token(self):
+        """
+        Enabling loggly.
 
-def test_configure_logging_with_invalid_token():
-    """
-    Enabling loggly.
-
-    """
-    def loader(metadata):
-        return dict(
-            logging=dict(
-                loggly=dict(
-                    token=environ.get("LOGGLY_TOKEN", "TOKEN"),
-                    environment="unittest",
+        """
+        def loader(metadata):
+            return dict(
+                logging=dict(
+                    loggly=dict(
+                        token=environ.get("LOGGLY_TOKEN", "TOKEN"),
+                        environment="unittest",
+                    )
                 )
             )
-        )
 
-    graph = create_object_graph(name="test", loader=loader)
-    graph.use("logger")
+        graph = create_object_graph(name="test", loader=loader)
+        graph.use("logger")
 
-    graph.logger.info("Info will appear in loggly if LOGGLY_TOKEN is set correctly.")
+        graph.logger.info("Info will appear in loggly if LOGGLY_TOKEN is set correctly.")
 
+    def test_extra_and_exc_info(self):
+        graph = create_object_graph(name="test", testing=True)
 
-def test_extra_and_exc_info():
-    graph = create_object_graph(name="test", testing=True)
+        try:
+            raise Exception("error")
+        except Exception:
+            graph.logger.info(
+                "Will include extra info and stack: {foo}",
+                exc_info=True,
+                extra=dict(foo="bar"),
+            )
 
-    try:
-        raise Exception("error")
-    except Exception:
-        graph.logger.info(
-            "Will include extra info and stack: {foo}",
-            exc_info=True,
-            extra=dict(foo="bar"),
-        )
+    def test_configure_logging_with_level_bump(self):
+        """
+        Logging levels can be bumped.
+
+        """
+        def loader(metadata):
+            return {
+                "logging": {
+                    "level": INFO,
+                    "levels": {
+                        "bump": {
+                            "bar": 10,
+                        },
+                    },
+                },
+            }
+
+        graph = create_object_graph(name="test", testing=True, loader=loader)
+        graph.use("logger")
+
+        with self.assertLogs("foo") as assert_logs:
+            getLogger("foo").info("Info message")
+            getLogger("foo").warning("Warning message")
+
+        assert_that(assert_logs.output, contains_exactly(
+            "INFO:foo:Info message",
+            "WARNING:foo:Warning message",
+        ))
+
+        with self.assertLogs("bar") as assert_logs:
+            getLogger("bar").info("Info message")
+            getLogger("bar").warning("Warning message")
+            getLogger("bar").critical("Critial message")
+
+        assert_that(assert_logs.output, contains_exactly(
+            "WARNING:bar:Info message",
+            "ERROR:bar:Warning message",
+            "CRITICAL:bar:Critial message",
+        ))


### PR DESCRIPTION
# Why?

For cases when you'd like to see low(er)-level logs from a 3rd party library.

When your logging handler along with other loggers is optimized for some level, e.g. `INFO`, and a 3rd party library is logging useful information below this threshold. Overriding logging level of a specific logger won't help, as the logs won't be picked up by the handler.