### PR TITLE
Add logstash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ To disable loggly unconditionally:
 To tune the logging levels of third-party components:
 
     config.logging.loggly.levels.override.warn = ["foo", "bar"]
+
+To enable logstash to work with a local client, enable it explicitly:
+
+    config.logging.logstash.enabled = True

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -12,7 +12,7 @@ from logging.config import dictConfig
 from os import environ
 from typing import Dict
 
-from microcosm.api import defaults
+from microcosm.api import defaults, typed
 
 
 @defaults(
@@ -66,7 +66,7 @@ from microcosm.api import defaults
 
     # logstash
     logstash=dict(
-        enabled=False,
+        enabled=typed(bool, default_value=False),
         host="localhost",
         port=5959,
     ),

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -10,6 +10,8 @@ from logging import (
 )
 from logging.config import dictConfig
 from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Dict
 
 from microcosm.api import defaults
@@ -62,6 +64,13 @@ from microcosm.api import defaults
     # loggly
     loggly=dict(
         base_url="https://logs-01.loggly.com",
+    ),
+
+    # logstash
+    logstash=dict(
+        enabled=False,
+        host="localhost",
+        port=5959,
     ),
 
     # configure stream handler
@@ -131,6 +140,10 @@ def make_dict_config(graph):
     if enable_loggly(graph):
         formatters["JSONFormatter"] = make_json_formatter(graph)
         handlers["LogglyHTTPSHandler"] = make_loggly_handler(graph, formatter="JSONFormatter")
+
+    # create the logstash handler only if explicitly configured
+    if graph.config.logging.logstash.enabled:
+        handlers["LogstashHandler"] = make_logstash_handler(graph)
 
     # configure the root logger to output to all handlers
     loggers[""] = {
@@ -211,6 +224,22 @@ def make_loggly_handler(graph, formatter):
         "formatter": formatter,
         "level": graph.config.logging.level,
         "url": loggly_url,
+    }
+
+
+def make_logstash_handler(graph):
+    """
+    Create the logstash handler
+
+    Relies on a temporary directory for the locally-cached database path
+    that is then streamed to a local logstash daemon. This is created in
+    the OS temp storage and will be garbage collected at an appropriate time.
+
+    """
+    return {
+        "class": "logstash_async.handler.SynchronousLogstashHandler",
+        "host": graph.config.logging.logstash.host,
+        "port": graph.config.logging.logstash.port,
     }
 
 

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -10,8 +10,6 @@ from logging import (
 )
 from logging.config import dictConfig
 from os import environ
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Dict
 
 from microcosm.api import defaults

--- a/microcosm_logging/tests/test_factories.py
+++ b/microcosm_logging/tests/test_factories.py
@@ -3,7 +3,6 @@ from logging import (
     INFO,
     WARN,
     getLogger,
-    log,
 )
 from os import environ
 from unittest import TestCase

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "microcosm>=2.12.0",
         "python-json-logger>=0.1.9",
         "requests[security]>=2.18.4",
+        "python-logstash-async>=2.3.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
When testing code locally, it's occasionally helpful to boot up a logstash handler and stream to some ETL destination (elasticsearch, file, etc). This PR adds support in microcosm-logging to introduce this at the configuration level.