### PR TITLE
Enable json format for stream handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ To set the global logging level to something other than info, use:
 
     config.logging.level = "WARN"
 
+To set the console logger format to json:
+
+    config.logging.stream_handler.formatter = "JSONFormatter"
+
 To enable loggly, set its `token` and configure an `environment` name:
 
     config.logging.loggly.token = "LOGGLY_TOKEN"

--- a/microcosm_logging/factories.py
+++ b/microcosm_logging/factories.py
@@ -74,6 +74,7 @@ from microcosm.api import defaults, typed
     # configure stream handler
     stream_handler=dict(
         class_="logging.StreamHandler",
+        formatter="ExtraFormatter",
         stream="ext://sys.stdout",
     ),
 )
@@ -130,13 +131,15 @@ def make_dict_config(graph):
     handlers = {}
     loggers = {}
 
-    # create the console handler
+    # create formatters
     formatters["ExtraFormatter"] = make_extra_console_formatter(graph)
-    handlers["console"] = make_stream_handler(graph, formatter="ExtraFormatter")
+    formatters["JSONFormatter"] = make_json_formatter(graph)
+
+    # create the console handler with the configured formatter
+    handlers["console"] = make_stream_handler(graph, formatter=graph.config.logging.stream_handler.formatter)
 
     # maybe create the loggly handler
     if enable_loggly(graph):
-        formatters["JSONFormatter"] = make_json_formatter(graph)
         handlers["LogglyHTTPSHandler"] = make_loggly_handler(graph, formatter="JSONFormatter")
 
     # create the logstash handler only if explicitly configured


### PR DESCRIPTION
- add config value for defining format of stream handler

Why?

To enable json format for console logging.